### PR TITLE
Fix dataloader lock & support larger batch size

### DIFF
--- a/train/dataloader.py
+++ b/train/dataloader.py
@@ -439,7 +439,7 @@ if __name__ == "__main__":
     train_loader = BatchDataLoader(train_loader, batch_size=batch_size)
     train_loader = BackgroundGenerator(train_loader)
 
-    valid_dataset = CommaDataset(comma_recordings_basedir, train_split=train_split, seq_len=seq_len, shuffle=True, single_frame_batches=single_frame_batches, validation=True)
+    valid_dataset = CommaDataset(comma_recordings_basedir, batch_size=batch_size, train_split=train_split, seq_len=seq_len, shuffle=True, single_frame_batches=single_frame_batches, validation=True)
     valid_loader = DataLoader(valid_dataset, batch_size=None, num_workers=num_workers, shuffle=False, prefetch_factor=prefetch_factor, persistent_workers=True, collate_fn=None)
     valid_loader = BatchDataLoader(valid_loader, batch_size=batch_size)
     valid_loader = BackgroundGenerator(valid_loader)

--- a/train/model.py
+++ b/train/model.py
@@ -8,7 +8,6 @@ from torch.nn.modules.linear import Identity
 from torch.nn.modules.rnn import LSTM
 import torchvision
 import numpy as np
-from torchsummary import summary
 
 """
 To do:: code refactoring, class summary and arguments description

--- a/train/train.py
+++ b/train/train.py
@@ -216,9 +216,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # for reproducibility 
-    seed = np.random.randint(2**16)
-    torch.manual_seed(seed)
-    print("=>seed={}".format(seed))
+    torch.manual_seed(args.seed)
+    print("=>seed={}".format(args.seed))
 
 
     # intializing the object of the logger class 


### PR DESCRIPTION
**Key changes:**
- Lock/getting stuck was fixed by moving the background collation function from a _thread_ to a _process_.
- Larger batch size is supported by pinning data loader workers to a single CPU each. This previously didn't work properly on machines where the list of CPUs available to the process was fragmented (such as on HPC); now fragmented lists of CPUs are also supported.

**Minor:**
- deterministic seed setting
- minor bug fixing/cleanup